### PR TITLE
Add fix for MC-88959.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Currently the mod provides fixes for the following bugs in 1.12.2:
   is generated at
 * [MC-80032](https://bugs.mojang.com/browse/MC-80032) - Horse suffocate when going through nether portals
 * [MC-83039](https://bugs.mojang.com/browse/MC-83039) - End City chests generate destroyed, items on the ground
+* [MC-88959](https://bugs.mojang.com/browse/MC-88959) - Piston no longer retracts an extended piston when de-powered at the same time
 * [MC-92916](https://bugs.mojang.com/browse/MC-92916) - Player is removed from the EntityTracker when teleporting to
   unloaded chunks or changing dimensions, resulting in client side desync
 * [MC-98153](https://bugs.mojang.com/browse/MC-98153) - Portals generate far-away chunks & set player on fire

--- a/build.gradle
+++ b/build.gradle
@@ -70,11 +70,7 @@ minecraft {
     serverJvmArgs.addAll(args)
 }
 
-sourceSets {
-    main {
-        refMap = "mixins.mup.refmap.json"
-    }
-}
+sourceSets.main.refMap = "mixins.mup.refmap.json"
 
 repositories {
     maven { url = "http://repo.spongepowered.org/maven" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Oct 27 21:07:40 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/src/main/java/org/gr1m/mc/mup/bugfix/mc88959/mixin/MixinBlockPistonBase.java
+++ b/src/main/java/org/gr1m/mc/mup/bugfix/mc88959/mixin/MixinBlockPistonBase.java
@@ -1,0 +1,26 @@
+package org.gr1m.mc.mup.bugfix.mc88959.mixin;
+
+import net.minecraft.block.BlockPistonBase;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.gr1m.mc.mup.Mup;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.minecraft.block.BlockPistonBase.EXTENDED;
+
+@Mixin(BlockPistonBase.class)
+public abstract class MixinBlockPistonBase
+{
+	@Inject(method = "checkForMove", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;addBlockEvent(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/Block;II)V", ordinal = 1))
+	private void onPistonDepower(World worldIn, BlockPos pos, IBlockState state, CallbackInfo ci)
+	{
+		if (Mup.config.mc88959.enabled)
+		{
+			worldIn.setBlockState(pos, state.withProperty(EXTENDED, false), 2);
+		}
+	}
+}

--- a/src/main/java/org/gr1m/mc/mup/config/MupConfig.java
+++ b/src/main/java/org/gr1m/mc/mup/config/MupConfig.java
@@ -139,6 +139,13 @@ public class MupConfig
         .setToggleable(false)
         .setComment(new String[] {"End City chests generate destroyed, items on the ground"});
 
+    public final PatchDef mc88959 = new PatchDef("mc88959", PatchDef.Side.SERVER)
+        .setDisplayName("MC-88959")
+        .setCredits("nessie")
+        .setCategory("bug fixes")
+        .setComment(new String[] {"Piston no longer retracts an extended piston when de-powered at the same time (instant piston double retraction)"});
+
+
     public final PatchDef mc92916 = new PatchDef("mc92916", PatchDef.Side.SERVER, PatchDef.ServerSyncHandlers.IGNORE, PatchDef.ClientSyncHandlers.IGNORE)
         .setDisplayName("MC-92916")
         .setCredits("Xcom, MrGrim")
@@ -319,12 +326,13 @@ public class MupConfig
                                   "This tweak is very nasty and should only be loaded for debugging purposes. It adds 4 bytes to every packet sent."});
 
     public final PatchDef redstoneplusplus = new PatchDef("redstoneplusplus", PatchDef.Side.BOTH, PatchDef.ServerSyncHandlers.IGNORE)
-        .setDisplayName("Redstone++ and MC-54026")
-        .setCredits("MrGrim")
+        .setDisplayName("Redstone++ Compatibility Fixes")
+        .setCredits("MrGrim, nessie")
+        .setSideEffects("Potentially breaks any and all piston contraptions that rely on extremely specific update order and block event delay (+among other things).")
         .setCategory("modpatches")
         .setToggleable(false)
         .setDefaults(new boolean[] { true, true })
-        .setComment(new String[] {"Extends MC-54026 support to Redstone++ pistons."});
+        .setComment(new String[] {"Extends MC-54026 and MC-88959 support to Redstone++ pistons."});
 
     public final PatchDef vanillafoamfix = new PatchDef("vanillafoamfix", PatchDef.Side.BOTH, PatchDef.ServerSyncHandlers.IGNORE)
         .setDisplayName("VanillaFix and FoamFix Compatibility")

--- a/src/main/java/org/gr1m/mc/mup/core/MupCoreCompat.java
+++ b/src/main/java/org/gr1m/mc/mup/core/MupCoreCompat.java
@@ -174,10 +174,10 @@ public class MupCoreCompat
         {
             List<String> supportedVersions = Arrays.asList("1.2d", "1.3 BETA-2");
 
-            if (!MupCore.config.mc54026.loaded)
+            if (!MupCore.config.mc54026.loaded && !MupCore.config.mc88959.loaded)
             {
                 patchIn.loaded = false;
-                patchIn.reason = "MC-54026 bug fix is not loaded.";
+                patchIn.reason = "Bug fixes for neither MC-88959 nor MC-54026 are loaded.";
 
                 return null;
             }

--- a/src/main/java/org/gr1m/mc/mup/core/MupCoreConfig.java
+++ b/src/main/java/org/gr1m/mc/mup/core/MupCoreConfig.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 public class MupCoreConfig {
 
-    private Configuration config;
+	private Configuration config;
     
     public class Patch {
         public boolean enabled;
@@ -55,6 +55,7 @@ public class MupCoreConfig {
     public Patch mc73051 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});
     public Patch mc80032 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});
     public Patch mc83039 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});
+    public Patch mc88959 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, false});
     public Patch mc92916 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});
     public Patch mc98153 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});
     public Patch mc108469 = new MupCoreConfig.Patch("bug fixes", new boolean[]{true, true});

--- a/src/main/java/org/gr1m/mc/mup/modcompat/redstoneplusplus/v12d/mixin/MixinBlockPistonBaseFix.java
+++ b/src/main/java/org/gr1m/mc/mup/modcompat/redstoneplusplus/v12d/mixin/MixinBlockPistonBaseFix.java
@@ -62,6 +62,10 @@ public abstract class MixinBlockPistonBaseFix extends BlockPistonBase
             }
         }
 
+        if (Mup.config.mc88959.enabled)
+        {
+            worldIn.setBlockState(pos, state.withProperty(EXTENDED, false), 2);
+        }
         worldIn.addBlockEvent(pos, blockIn, eventID, eventParam | suppress_move);
     }
 

--- a/src/main/java/org/gr1m/mc/mup/modcompat/redstoneplusplus/v13b2/mixin/MixinBlockPistonBaseFix.java
+++ b/src/main/java/org/gr1m/mc/mup/modcompat/redstoneplusplus/v13b2/mixin/MixinBlockPistonBaseFix.java
@@ -125,6 +125,10 @@ public abstract class MixinBlockPistonBaseFix extends BlockPistonBase
                 }
             }
 
+            if (Mup.config.mc88959.enabled)
+            {
+                worldIn.setBlockState(pos, state.withProperty(EXTENDED, false), 2);
+            }
             worldIn.addBlockEvent(pos, this, 1, enumfacing.getIndex() | suppress_move);
         }
     }

--- a/src/main/resources/mixins.mc88959.json
+++ b/src/main/resources/mixins.mc88959.json
@@ -1,0 +1,10 @@
+{
+  "package": "org.gr1m.mc.mup.bugfix.mc88959.mixin",
+  "refmap": "mixins.mup.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.7.4",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  "MixinBlockPistonBase"
+  ]
+}


### PR DESCRIPTION
Note: disabled by default since it can break some very specific update-order-related redstone contraptions.